### PR TITLE
bhayes/list alias

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ dist
 
 # TODO file
 TODO.txt
+
+# IntelliJ Project
+.idea

--- a/commands/ls/ls.go
+++ b/commands/ls/ls.go
@@ -44,7 +44,7 @@ func NewCmd(db *bolt.DB) *cobra.Command {
 		Long: `List entries.
 
 Listing all the entries does not check for expired entries, this decision was taken to prevent high loads when the number of entries is elevated. Listing a single entry does notifies if it is expired.`,
-		Aliases: []string{"entries"},
+		Aliases: []string{"entries", "list"},
 		Example: example,
 		Args:    cmdutil.MustExistLs(db, cmdutil.Entry),
 		PreRunE: auth.Login(db),

--- a/docs/commands/ls.md
+++ b/docs/commands/ls.md
@@ -2,7 +2,7 @@
 
 `kure ls <name> [-f filter] [-q qr] [-s show]`
 
-*Aliases*: ls, entries.
+*Aliases*: ls, entries, list.
 
 ## Description
 


### PR DESCRIPTION
## Changes

﻿- updated gitignore to ignore intellij goland project files
- Added `list` alias to `ls` command

## Description

This pull request adds the `list` alias to the `ls` command so that users can use `kure [ls | entries | list]` interchangeably.


> Looks like some tests are failing but I don't believe it's related to my changes, considering my chages are so minor.
