### PR TITLE
Compact database on backup

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Finally, it's important to mention that **password comparisons are done in const
 
 Data encryption is done using a **256-bit key**, the symmetric block cipher [AES](https://en.wikipedia.org/wiki/Advanced_Encryption_Standard) (Advanced Encryption Standard) along with [GCM](https://en.wikipedia.org/wiki/Galois/Counter_Mode) (Galois/Counter Mode) a cipher mode providing an [authenticated encryption](https://en.wikipedia.org/wiki/Authenticated_encryption) algorithm designed to ensure data authenticity, integrity and confidentiality.
 
-Names are obfuscated using a bitwise xor operation and the authentication key, which is encrypted and used to determine whether the password is correct by decrypting it at the start of every command.
+Names are obfuscated using the bitwise XOR operation and the authentication key, which is encrypted and used to determine whether the password is correct by decrypting it at the start of every command.
 
 This way, we ensure that the record names are not in plaintext while being able to access them without using a compute-expensive operation.
 

--- a/commands/backup/backup.go
+++ b/commands/backup/backup.go
@@ -128,17 +128,17 @@ func fileBackup(db *bolt.DB, path string) error {
 		return errors.Wrap(err, "changing working directory")
 	}
 
-	f, err := os.OpenFile(filepath.Base(path), os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+	newDB, err := bolt.Open(filepath.Base(path), 0o600, nil)
 	if err != nil {
-		return errors.Wrap(err, "opening file")
+		return errors.Wrap(err, "opening database backup")
 	}
 
-	if err := writeTo(db, f); err != nil {
-		return err
+	if err := bolt.Compact(newDB, db, 0); err != nil {
+		return errors.Wrap(err, "compacting database backup")
 	}
 
-	if err := f.Close(); err != nil {
-		return errors.Wrap(err, "closing file")
+	if err := newDB.Close(); err != nil {
+		return errors.Wrap(err, "closing database backup")
 	}
 
 	abs, _ := filepath.Abs(path)


### PR DESCRIPTION
## Description

Changes the way in which databases are backed up.

Instead of copying the entire file from one place to another, it will recreate all records one by one and discard those that were marked as removed (or have no references) to reclaim space. The source database remains unchanged.