### PR TITLE
Stateless commands

### DIFF
--- a/commands/card/ls/ls.go
+++ b/commands/card/ls/ls.go
@@ -48,7 +48,7 @@ func NewCmd(db *bolt.DB) *cobra.Command {
 
 	f := cmd.Flags()
 	f.BoolVarP(&opts.filter, "filter", "f", false, "filter by name")
-	f.BoolVarP(&opts.qr, "qr", "q", false, "show the number QR code on the terminal")
+	f.BoolVarP(&opts.qr, "qr", "q", false, "display the QR code of the number on the terminal")
 	f.BoolVarP(&opts.show, "show", "s", false, "show card number and security code")
 
 	return cmd
@@ -104,9 +104,7 @@ func runLs(db *bolt.DB, opts *lsOptions) cmdutil.RunEFunc {
 		}
 
 		if opts.qr {
-			if err := terminal.DisplayQRCode(c.Number); err != nil {
-				return err
-			}
+			return terminal.DisplayQRCode(c.Number)
 		}
 
 		printCard(name, c, opts.show)

--- a/commands/gen/gen.go
+++ b/commands/gen/gen.go
@@ -63,7 +63,7 @@ Average time taken to crack is based on a brute force attack scenario where the 
 	f.StringVarP(&opts.include, "include", "i", "", "characters to include in the password")
 	f.StringVarP(&opts.exclude, "exclude", "e", "", "characters to exclude from the password")
 	f.BoolVarP(&opts.repeat, "repeat", "r", false, "allow character repetition")
-	f.BoolVarP(&opts.qr, "qr", "q", false, "show the QR code image on the terminal")
+	f.BoolVarP(&opts.qr, "qr", "q", false, "display the password QR code on the terminal")
 	f.BoolVarP(&opts.mute, "mute", "m", false, "mute standard output when the password is copied")
 
 	return cmd
@@ -111,14 +111,12 @@ func runGen(opts *genOptions) cmdutil.RunEFunc {
 			return err
 		}
 
-		pwdBuf := memguard.NewBufferFromBytes([]byte(password))
-		memguard.WipeBytes([]byte(password))
+		pwdBuf := memguard.NewBufferFromBytes(password)
+		memguard.WipeBytes(password)
 		defer pwdBuf.Destroy()
 
 		if opts.qr {
-			if err := terminal.DisplayQRCode(pwdBuf.String()); err != nil {
-				return err
-			}
+			return terminal.DisplayQRCode(pwdBuf.String())
 		}
 
 		entropy := p.Entropy()

--- a/commands/gen/phrase/phrase.go
+++ b/commands/gen/phrase/phrase.go
@@ -81,7 +81,7 @@ Average time taken to crack is based on a brute force attack scenario where the 
 	f.StringVarP(&opts.list, "list", "L", "WordList", "passphrase list used {NoList|WordList|SyllableList}")
 	f.StringSliceVarP(&opts.incl, "include", "i", nil, "words to include in the passphrase")
 	f.StringSliceVarP(&opts.excl, "exclude", "e", nil, "words to exclude from the passphrase")
-	f.BoolVarP(&opts.qr, "qr", "q", false, "show QR code on terminal")
+	f.BoolVarP(&opts.qr, "qr", "q", false, "display the passphrase QR code on terminal")
 	f.BoolVarP(&opts.mute, "mute", "m", false, "mute standard output when the passphrase is copied")
 
 	return cmd
@@ -126,14 +126,12 @@ func runPhrase(opts *phraseOptions) cmdutil.RunEFunc {
 			return err
 		}
 
-		phraseBuf := memguard.NewBufferFromBytes([]byte(passphrase))
-		memguard.WipeBytes([]byte(passphrase))
+		phraseBuf := memguard.NewBufferFromBytes(passphrase)
+		memguard.WipeBytes(passphrase)
 		defer phraseBuf.Destroy()
 
 		if opts.qr {
-			if err := terminal.DisplayQRCode(phraseBuf.String()); err != nil {
-				return err
-			}
+			return terminal.DisplayQRCode(phraseBuf.String())
 		}
 
 		entropy := p.Entropy()

--- a/commands/ls/ls.go
+++ b/commands/ls/ls.go
@@ -56,7 +56,7 @@ Listing all the entries does not check for expired entries, this decision was ta
 
 	f := cmd.Flags()
 	f.BoolVarP(&opts.filter, "filter", "f", false, "filter by name")
-	f.BoolVarP(&opts.qr, "qr", "q", false, "show the password QR code on the terminal")
+	f.BoolVarP(&opts.qr, "qr", "q", false, "display the password QR code on the terminal")
 	f.BoolVarP(&opts.show, "show", "s", false, "show entry password")
 
 	return cmd
@@ -112,9 +112,7 @@ func runLs(db *bolt.DB, opts *lsOptions) cmdutil.RunEFunc {
 		}
 
 		if opts.qr {
-			if err := terminal.DisplayQRCode(e.Password); err != nil {
-				return err
-			}
+			return terminal.DisplayQRCode(e.Password)
 		}
 
 		printEntry(name, e, opts.show)

--- a/commands/root/root.go
+++ b/commands/root/root.go
@@ -99,3 +99,13 @@ func printVersion() {
 
 	fmt.Printf("[%s] %s %s\n", bi.GoVersion, bi.Main.Version, lastCommitHash)
 }
+
+// StatelessCommand returns true if the specified command does not require opening the database.
+func StatelessCommand(command string) bool {
+	for _, name := range []string{"clear", "gen", "help"} {
+		if name == command {
+			return true
+		}
+	}
+	return false
+}

--- a/commands/root/root_test.go
+++ b/commands/root/root_test.go
@@ -58,3 +58,42 @@ func TestRunnable(t *testing.T) {
 		}
 	}
 }
+
+func TestStatelessCommand(t *testing.T) {
+	cases := []struct {
+		commandName string
+		expected    bool
+	}{
+		{
+			commandName: "",
+			expected:    false,
+		},
+		{
+			commandName: "help",
+			expected:    true,
+		},
+		{
+			commandName: "add",
+			expected:    false,
+		},
+		{
+			commandName: "gen",
+			expected:    true,
+		},
+		{
+			commandName: "clear",
+			expected:    true,
+		},
+		{
+			commandName: "it",
+			expected:    false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.commandName, func(t *testing.T) {
+			got := root.StatelessCommand(tc.commandName)
+			assert.Equal(t, tc.expected, got)
+		})
+	}
+}

--- a/docs/commands/card/subcommands/ls.md
+++ b/docs/commands/card/subcommands/ls.md
@@ -11,7 +11,7 @@ List cards.
 |  Name     | Shorthand |     Type      |    Default    |                 Description                   |
 |-----------|-----------|---------------|---------------|-----------------------------------------------|
 | filter    | f         | bool          | false         | Filter cards                                  |
-| qr        | q         | bool          | false         | Display card number QR code on the terminal   |
+| qr        | q         | bool          | false         | Display the number QR code on the terminal   	|
 | show      | s         | bool          | false         | Show card number and security code            |
 
 ### Examples

--- a/docs/commands/gen/gen.md
+++ b/docs/commands/gen/gen.md
@@ -20,8 +20,8 @@ Generate a random password.
 | include   | i         | string        | ""            | Characters to include in the password             |
 | exclude   | e         | string        | ""            | Characters to exclude from the password           |
 | repeat    | r         | bool          | false         | Character repetition                              |
-| qr        | q         | bool          | false         | Show QR code image on the terminal                |
-| mute      | m         | bool          | false         | Mute standard output when the password is copied  |
+| qr        | q         | bool          | false         | Display the password QR code on the terminal		|
+| mute      | m         | bool          | false         | Mute standard output when the password is copied 	|
 
 ### Format levels
 

--- a/docs/commands/gen/subcommands/phrase.md
+++ b/docs/commands/gen/subcommands/phrase.md
@@ -18,7 +18,7 @@ Generate a random passphrase.
 | include   | i         | []string      | nil           | Words to include in the passphrase                            |
 | exclude   | e         | []string      | nil           | Words to exclude from the passphrase                          |
 | list      | L         | string        | "WordList"    | Passphrase generating method (NoList, WordList, SyllableList) |
-| qr        | q         | bool          | false         | Show the QR code image on the terminal                        |
+| qr        | q         | bool          | false         | Display the passphrase QR code image on the terminal			|
 | mute      | m         | bool          | false         | Mute standard output when the passphrase is copied            |
 
 ### Examples

--- a/docs/commands/ls.md
+++ b/docs/commands/ls.md
@@ -12,11 +12,11 @@ List entries.
 
 ## Flags 
 
-|  Name     | Shorthand |     Type      |    Default    |                                  Description                                         |
-|-----------|-----------|---------------|---------------|--------------------------------------------------------------------------------------|
-| filter    | f         | bool          | false         | Filter entries                                                                       |
-| qr        | q         | bool          | false         | Show the password QR code on the terminal (non-available when listing all entries)   |
-| show      | s         | bool          | false         | Show entry password                                                                  |
+|  Name     | Shorthand |     Type      |    Default    |                                  Description                                         	|
+|-----------|-----------|---------------|---------------|---------------------------------------------------------------------------------------|
+| filter    | f         | bool          | false         | Filter entries                                                                       	|
+| qr        | q         | bool          | false         | Display the password QR code on the terminal (not-available when listing all entries)	|
+| show      | s         | bool          | false         | Show entry password                                                                  	|
 
 ### Examples
 

--- a/main.go
+++ b/main.go
@@ -21,6 +21,15 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Check for and run stateless commands
+	if len(os.Args) < 2 || root.StatelessCommand(os.Args[1]) {
+		if err := root.NewCmd(nil).Execute(); err != nil {
+			fmt.Fprintln(os.Stderr, "error:", err)
+			os.Exit(1)
+		}
+		os.Exit(0)
+	}
+
 	dbPath := filepath.Clean(config.GetString("database.path"))
 	db, err := bolt.Open(dbPath, 0o600, &bolt.Options{Timeout: 200 * time.Millisecond})
 	if err != nil {

--- a/terminal/terminal.go
+++ b/terminal/terminal.go
@@ -72,7 +72,7 @@ func DisplayQRCode(secret string) error {
 		return errors.Wrap(err, "creating QR code")
 	}
 
-	fmt.Println(qr.ToSmallString(false))
+	fmt.Print(qr.ToSmallString(false))
 	return nil
 }
 


### PR DESCRIPTION
## Description

Differentiates commands that do not access the database (stateless) from the other ones, to avoid the need of logging in to execute them.

It also modifies the `--qr` flag to display only the secret QR code and not the rest of the record information.