### PR TITLE
Use compression if the content is not empty

### DIFF
--- a/commands/file/mv/mv_test.go
+++ b/commands/file/mv/mv_test.go
@@ -1,7 +1,6 @@
 package mv
 
 import (
-	"runtime"
 	"strconv"
 	"strings"
 	"testing"
@@ -75,10 +74,6 @@ func TestMvFileIntoDir(t *testing.T) {
 }
 
 func TestMvErrors(t *testing.T) {
-	if runtime.GOOS != "windows" {
-		t.Skip("For some strange reason this test fails in unix systems because the database file throws \"bad file descriptor\"")
-	}
-
 	db := cmdutil.SetContext(t)
 	createFile(t, db, "exists")
 	dir := "dir/"

--- a/db/file/file.go
+++ b/db/file/file.go
@@ -130,6 +130,10 @@ func Rename(db *bolt.DB, oldName, newName string) error {
 }
 
 func compress(content []byte) ([]byte, error) {
+	if len(content) == 0 {
+		return nil, nil
+	}
+
 	var gzipBuf bytes.Buffer
 	gw := gzip.NewWriter(&gzipBuf)
 
@@ -145,6 +149,10 @@ func compress(content []byte) ([]byte, error) {
 }
 
 func decompress(content []byte) ([]byte, error) {
+	if len(content) == 0 {
+		return nil, nil
+	}
+
 	compressed := bytes.NewBuffer(content)
 	gr, err := gzip.NewReader(compressed)
 	if err != nil {

--- a/db/file/file_test.go
+++ b/db/file/file_test.go
@@ -202,6 +202,38 @@ func TestKeyError(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestCompression(t *testing.T) {
+	content := []byte{1, 2, 3}
+
+	compressed, err := compress(content)
+	assert.NoError(t, err)
+
+	assert.NotEqual(t, content, compressed)
+
+	decompressed, err := decompress(compressed)
+	assert.NoError(t, err)
+
+	assert.Equal(t, content, decompressed)
+}
+
+func TestCompressNil(t *testing.T) {
+	var content []byte
+
+	compressed, err := compress(content)
+	assert.NoError(t, err)
+
+	assert.Equal(t, content, compressed)
+}
+
+func TestDecompressNil(t *testing.T) {
+	var content []byte
+
+	decompressed, err := decompress(content)
+	assert.NoError(t, err)
+
+	assert.Equal(t, content, decompressed)
+}
+
 func setContext(t testing.TB) *bolt.DB {
 	return dbutil.SetContext(t, bucket.File.GetName())
 }


### PR DESCRIPTION
## Description

Skips compression and decompression of a file's content if it's empty. Previously, it was storing GZIP's headers and an empty body.