### PR TITLE
Fix typos

### DIFF
--- a/commands/2fa/add/add.go
+++ b/commands/2fa/add/add.go
@@ -38,7 +38,7 @@ func NewCmd(db *bolt.DB, r io.Reader) *cobra.Command {
 		Short: "Add a two-factor authentication code",
 		Long: `Add a two-factor authentication code.
 
-• Using a setup key: services tipically show hyperlinked text like "Enter manually" or "Enter this text code", copy the hexadecimal code given and submit it when requested.
+• Using a setup key: services typically show hyperlinked text like "Enter manually" or "Enter this text code", copy the hexadecimal code given and submit it when requested.
 
 • Using a URL: extract the URL encoded in the QR code given and submit it when requested. Format: otpauth://totp/{service}:{account}?secret={secret}.`,
 		Example: example,

--- a/commands/it/it.go
+++ b/commands/it/it.go
@@ -138,7 +138,7 @@ func requestCommands(db *bolt.DB, root *cobra.Command, receivedCmds []string) ([
 	}
 
 	args := append(commands, flags...)
-	// Preprend the received commands if there is any
+	// Prepend the received commands if there is any
 	// We would have [received commands] [commands] [flags]
 	if len(receivedCmds) > 0 {
 		args = append(receivedCmds, args...)

--- a/commands/it/select.go
+++ b/commands/it/select.go
@@ -27,7 +27,7 @@ func selectCommands(parent *cobra.Command) ([]string, error) {
 		list[i] = c.Name()
 	}
 
-	// Only when it isn't root, preprend "self",
+	// Only when it isn't root, prepend "self",
 	// which is used for executing the current command
 	if parent.HasParent() {
 		list = append([]string{"self"}, list...)

--- a/commands/session/util_test.go
+++ b/commands/session/util_test.go
@@ -183,7 +183,7 @@ func TestRemoveEmptyItems(t *testing.T) {
 			expected: []string{"timeout", "&&", "clear"},
 		},
 		{
-			desc:     "Do not remove arguments surronded by spaces",
+			desc:     "Do not remove arguments surrounded by spaces",
 			args:     []string{"kure", " file ", " ", "ls"},
 			expected: []string{"kure", " file ", "ls"},
 		},

--- a/config/config.go
+++ b/config/config.go
@@ -10,7 +10,7 @@ import (
 	"github.com/spf13/cast"
 )
 
-// Init intializes the configuration.
+// Init initializes the configuration.
 func Init() error {
 	configPath, err := getConfigPath()
 	if err != nil {

--- a/docs/commands/2fa/subcommands/add.md
+++ b/docs/commands/2fa/subcommands/add.md
@@ -6,7 +6,7 @@
 
 Add a two-factor authentication code.
 
-- **Using a setup key**: services tipically show hyperlinked text like "Enter manually" or "Enter this text code", copy the hexadecimal code given and submit it when requested.
+- **Using a setup key**: services typically show hyperlinked text like "Enter manually" or "Enter this text code", copy the hexadecimal code given and submit it when requested.
 
 - **Using a URL**: extract the URL encoded in the QR code given and submit it when requested. Format: otpauth://totp/{service}:{account}?secret={secret}.
 

--- a/docs/commands/add/add.md
+++ b/docs/commands/add/add.md
@@ -17,7 +17,7 @@ Create an entry using a password.
 |  Name     | Shorthand |     Type      |    Default    |                Description                   |
 |-----------|-----------|---------------|---------------|----------------------------------------------|
 | custom    | c         | bool          | false         | Create an entry with a custom password       |
-| length    | l         | uint64        | 0             | Pasword length                               |
+| length    | l         | uint64        | 0             | Password length                               |
 | levels    | L         | []int         | [1,2,3,4,5]   | Password levels                              |
 | include   | i         | string        | ""            | Characters to include in the password        |
 | exclude   | e         | string        | ""            | Characters to exclude in the password        |

--- a/docs/commands/card/subcommands/ls.md
+++ b/docs/commands/card/subcommands/ls.md
@@ -16,7 +16,7 @@ List cards.
 
 ### Examples
 
-List a card showin sensitive information:
+List a card showing sensitive information:
 ```
 kure card ls Sample -s
 ```

--- a/docs/commands/gen/gen.md
+++ b/docs/commands/gen/gen.md
@@ -15,7 +15,7 @@ Generate a random password.
 |  Name     | Shorthand |     Type      |    Default    |                   Description                     |
 |-----------|-----------|---------------|---------------|---------------------------------------------------|
 | copy      | c         | bool          | false         | Create an entry with a custom password            |
-| length    | l         | uint64        | 0             | Pasword length                                    |
+| length    | l         | uint64        | 0             | Password length                                    |
 | levels    | L         | []int         | [1,2,3,4,5]   | Password levels                                   |
 | include   | i         | string        | ""            | Characters to include in the password             |
 | exclude   | e         | string        | ""            | Characters to exclude from the password           |

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -55,7 +55,7 @@ The command of the editor you would like to use. If no editor is set in the conf
 
 > Must be absolute.
 
-The path to the key file may be specified or not, in case it's not, the user will be asked for it everytime he wants to access the database, in the other case the user has to input the password only.
+The path to the key file may be specified or not, in case it's not, the user will be asked for it every time he wants to access the database, in the other case the user has to input the password only.
 
 ---
 

--- a/migration/v1/main.go
+++ b/migration/v1/main.go
@@ -82,7 +82,7 @@ func xorNames(db *bolt.DB, r io.Reader) error {
 	}
 
 	if err := tx.Commit(); err != nil {
-		return errors.Wrap(err, "commiting transaction")
+		return errors.Wrap(err, "committing transaction")
 	}
 
 	return nil

--- a/tree/tree_test.go
+++ b/tree/tree_test.go
@@ -81,7 +81,7 @@ func BenchmarkTree(b *testing.B) {
 		"root",
 		"multi/planetary/life",
 		"go/src/github.com/GGP1/kure",
-		"super/long/path/contaning/folders/subfolders/and/files",
+		"super/long/path/containing/folders/subfolders/and/files",
 		"go/src/github.com/<username>/<project>",
 	}
 


### PR DESCRIPTION
Found via `codespell -L te,childs`