### PR TITLE
Change repeat field default value

### DIFF
--- a/commands/add/add.go
+++ b/commands/add/add.go
@@ -57,7 +57,7 @@ func NewCmd(db *bolt.DB, r io.Reader) *cobra.Command {
 	f.IntSliceVarP(&opts.levels, "levels", "L", []int{1, 2, 3, 4, 5}, "password levels")
 	f.StringVarP(&opts.include, "include", "i", "", "characters to include in the password")
 	f.StringVarP(&opts.exclude, "exclude", "e", "", "characters to exclude from the password")
-	f.BoolVarP(&opts.repeat, "repeat", "r", false, "allow character repetition")
+	f.BoolVarP(&opts.repeat, "repeat", "r", true, "allow character repetition")
 
 	return cmd
 }

--- a/commands/gen/gen.go
+++ b/commands/gen/gen.go
@@ -61,7 +61,7 @@ Average time taken to crack is based on a brute force attack scenario where the 
 	f.IntSliceVarP(&opts.levels, "levels", "L", []int{1, 2, 3, 4, 5}, "password levels")
 	f.StringVarP(&opts.include, "include", "i", "", "characters to include in the password")
 	f.StringVarP(&opts.exclude, "exclude", "e", "", "characters to exclude from the password")
-	f.BoolVarP(&opts.repeat, "repeat", "r", false, "allow character repetition")
+	f.BoolVarP(&opts.repeat, "repeat", "r", true, "allow character repetition")
 	f.BoolVarP(&opts.qr, "qr", "q", false, "display the password QR code on the terminal")
 	f.BoolVarP(&opts.mute, "mute", "m", false, "mute standard output when the password is copied")
 

--- a/docs/commands/add/add.md
+++ b/docs/commands/add/add.md
@@ -17,11 +17,11 @@ Create an entry using a password.
 |  Name     | Shorthand |     Type      |    Default    |                Description                   |
 |-----------|-----------|---------------|---------------|----------------------------------------------|
 | custom    | c         | bool          | false         | Create an entry with a custom password       |
-| length    | l         | uint64        | 0             | Password length                               |
+| length    | l         | uint64        | 0             | Password length                              |
 | levels    | L         | []int         | [1,2,3,4,5]   | Password levels                              |
 | include   | i         | string        | ""            | Characters to include in the password        |
 | exclude   | e         | string        | ""            | Characters to exclude in the password        |
-| repeat    | r         | bool          | false         | Character repetition                         |
+| repeat    | r         | bool          | true          | Character repetition                         |
 
 ### Format levels
 

--- a/docs/commands/gen/gen.md
+++ b/docs/commands/gen/gen.md
@@ -15,11 +15,11 @@ Generate a random password.
 |  Name     | Shorthand |     Type      |    Default    |                   Description                     |
 |-----------|-----------|---------------|---------------|---------------------------------------------------|
 | copy      | c         | bool          | false         | Create an entry with a custom password            |
-| length    | l         | uint64        | 0             | Password length                                    |
+| length    | l         | uint64        | 0             | Password length                                   |
 | levels    | L         | []int         | [1,2,3,4,5]   | Password levels                                   |
 | include   | i         | string        | ""            | Characters to include in the password             |
 | exclude   | e         | string        | ""            | Characters to exclude from the password           |
-| repeat    | r         | bool          | false         | Character repetition                              |
+| repeat    | r         | bool          | true          | Character repetition                              |
 | qr        | q         | bool          | false         | Display the password QR code on the terminal		|
 | mute      | m         | bool          | false         | Mute standard output when the password is copied 	|
 


### PR DESCRIPTION
## Description

Changes the `repeat` field value to `true` to allow repeated characters in the password generation by default.