### PR TITLE
Add stats command `--json` flag

### DIFF
--- a/commands/stats/stats.go
+++ b/commands/stats/stats.go
@@ -1,7 +1,9 @@
 package stats
 
 import (
+	"encoding/json"
 	"fmt"
+	"os"
 
 	cmdutil "github.com/GGP1/kure/commands"
 	"github.com/GGP1/kure/db/bucket"
@@ -12,20 +14,34 @@ import (
 )
 
 const example = `
-kure stats`
+* Show statistics
+kure stats
+
+* Show statistics in JSON format
+kure stats --json`
+
+type statsOptions struct {
+	json bool
+}
 
 // NewCmd returns a new command.
 func NewCmd(db *bolt.DB) *cobra.Command {
-	return &cobra.Command{
+	opts := statsOptions{}
+	cmd := &cobra.Command{
 		Use:     "stats",
 		Short:   "Show database statistics",
 		Example: example,
-		RunE:    runStats(db),
+		RunE:    runStats(db, &opts),
 	}
+
+	f := cmd.Flags()
+	f.BoolVar(&opts.json, "json", false, "output statistics in JSON format")
+
+	return cmd
 }
 
-func runStats(db *bolt.DB) cmdutil.RunEFunc {
-	return func(cmd *cobra.Command, args []string) error {
+func runStats(db *bolt.DB, opts *statsOptions) cmdutil.RunEFunc {
+	return func(_ *cobra.Command, _ []string) error {
 		tx, err := db.Begin(false)
 		if err != nil {
 			return errors.Wrap(err, "opening transaction")
@@ -37,6 +53,20 @@ func runStats(db *bolt.DB) cmdutil.RunEFunc {
 		nFiles := tx.Bucket(bucket.File.GetName()).Stats().KeyN
 		nTOTPs := tx.Bucket(bucket.TOTP.GetName()).Stats().KeyN
 		total := nCards + nEntries + nFiles + nTOTPs
+
+		if opts.json {
+			stats := map[string]int{
+				"cards":   nCards,
+				"entries": nEntries,
+				"files":   nFiles,
+				"totps":   nTOTPs,
+				"total":   total,
+			}
+			if err := json.NewEncoder(os.Stdout).Encode(stats); err != nil {
+				return errors.Wrap(err, "encoding statistics to JSON")
+			}
+			return nil
+		}
 
 		fmt.Printf(`
      STATISTICS

--- a/docs/commands/stats.md
+++ b/docs/commands/stats.md
@@ -8,10 +8,18 @@ Show database statistics.
 
 ## Flags 
 
-No flags.
+|  Name     |     Type      |    Default    |              Description                |
+|-----------|---------------|---------------|-----------------------------------------|
+| json      | bool          | false         | Output statistics in JSON format        |
 
 ### Examples
 
+Show statistics:
 ```
 kure stats
+```
+
+Show statistics in JSON format:
+```
+kure stats --json
 ```


### PR DESCRIPTION
## Description

Adds the `--json` flag to the `stats` command to output statistics in JSON format.

Closes https://github.com/GGP1/kure/issues/73.